### PR TITLE
EIN-40991

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Adds a 7-day npm `min-release-age` cooldown so installs/updates only resolve package versions at least a week old (EIN-40991).

This repo runs `npm ci` on the host (no Docker/CI), so the cooldown is set via a committed `.npmrc` (`min-release-age=7`). Takes effect on host npm ≥ 11.10; harmless on older npm.